### PR TITLE
Use Homebrew's ngrok

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -96,9 +96,6 @@ pyenv virtualenvwrapper_lazy
 eval "$(rbenv init -)"
 export PATH="$HOME/.rbenv/bin:$PATH"
 
-# ngrok
-alias ngrok="/Applications/ngrok"
-
 # nvm
 export NVM_DIR="$HOME/.nvm"
 . "$(brew --prefix nvm)/nvm.sh"


### PR DESCRIPTION
I used to use `ngrok` as a standalone application. This PR removes the alias I used to use and uses ngrok from Homebrew instead.